### PR TITLE
Fixed hardcoded path in glob copy, blocking assets after eject

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,7 @@ function getPlugins() {
       "favicon.ico"
     ],
     "globOptions": {
-      "cwd": "C:\\_PROJECTS\\_PERSO\\angular-electron\\src",
+      "cwd": process.cwd() + "/src",
       "dot": true,
       "ignore": "**/.gitkeep"
     }


### PR DESCRIPTION
angular cli after eject hardcodes path, so it must be changed to relative process.cwd() + "/src",
then assets copy will work correctly