### PR TITLE
Fix npm run build:prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "start:web": "webpack-dev-server --content-base . --port 4200 --inline",
     "build:electron:main": "tsc main.ts --outDir dist && copyfiles package.json dist && cd dist && npm install --prod && cd ..",
     "build": "webpack --display-error-details && npm run build:electron:main",
-    "build:prod": "cross-env NODE_ENV='production' npm run build",
+    "build:prod": "cross-env NODE_ENV='production' && npm run build",
     "electron:serve": "npm run build:electron:main && electron ./dist --serve",
     "electron:test": "electron ./dist",
     "electron:dev": "npm run build && electron ./dist",


### PR DESCRIPTION
When npm run electron:linux,  its failed with error:
npm ERR! Failed at the my-electron-project@0.0.1 build:prod script 'cross-env NODE_ENV='production' npm run build'.

I simply add && in  "cross-env NODE_ENV='production' && npm run build"

That does not happen in the standard project.

