### PR TITLE
Add buffer to externals

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -204,6 +204,7 @@ module.exports = {
   "devtool": "source-map",
   "externals": {
     "electron": "require('electron')",
+    "buffer": "require('buffer')",
     "child_process": "require('child_process')",
     "crypto": "require('crypto')",
     "events": "require('events')",


### PR DESCRIPTION
Add buffer as external library. Else some other buffer libary (browser buffer) will be used, which will break some other libraries (e.g. MySQL).