### PR TITLE
Add support for building a single executable for Windows

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -1,0 +1,10 @@
+{
+    "directories": {
+        "app": "dist",
+        "output": "app-builds"
+    },
+    "win": {
+        "icon": "dist/favicon",
+        "target": ["portable"]
+    }
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "electron:prod": "npm run build:prod && electron ./dist",
     "electron:linux": "npm run build:prod && node package.js --asar --platform=linux --arch=x64",
     "electron:windows": "npm run build:prod && node package.js --asar --platform=win32 --arch=ia32",
+    "electron:winportable": "npm run build:prod && npx electron-builder build --windows",
     "electron:mac": "npm run build:prod && node package.js --asar --platform=darwin --arch=x64",
     "test": "karma start ./karma.conf.js",
     "pree2e": "webdriver-manager update --standalone false --gecko false --quiet && npm run build",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "css-loader": "0.28.7",
     "cssnano": "3.10.0",
     "electron": "1.7.8",
-    "electron-builder": "^19.45.4",
+    "electron-builder": "19.45.4",
     "electron-packager": "9.1.0",
     "electron-reload": "1.2.1",
     "exports-loader": "0.6.4",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "css-loader": "0.28.7",
     "cssnano": "3.10.0",
     "electron": "1.7.8",
+    "electron-builder": "^19.45.4",
     "electron-packager": "9.1.0",
     "electron-reload": "1.2.1",
     "exports-loader": "0.6.4",


### PR DESCRIPTION
When building for Windows, sometimes it is desirable to include everything in a single `.exe` file rather than having a directory full of files. This PR leverages `electron-builder` to provide this option.

The build process runs just fine under macOS and Linux as well (Wine is downloaded and cached as needed).

**Warning:** for this to work, the `favicon.ico` can be a multiple-size version and _it must_ include one version of at least 256x256 size.