### PR TITLE
Update LICENSE badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Travis Build Status][build-badge]][build]
 [![Dependencies Status][dependencyci-badge]][dependencyci]
 [![Make a pull request][prs-badge]][prs]
-[![Apache 2 License][license-badge]][license]
+[![License](http://img.shields.io/badge/Licence-MIT-brightgreen.svg)](LICENSE.md)
 
 [![Watch on GitHub][github-watch-badge]][github-watch]
 [![Star on GitHub][github-star-badge]][github-star]


### PR DESCRIPTION
Looks like you changed the License for this project recently to MIT, but the repo badge still states the Apache 2.0 license.
