### PR TITLE
version bump + logo resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
   <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/zEig29HrXXTTPEH8HY8Qmk5p/maximegris/angular-electron.svg' />
 </a>
 
-[![Angular Logo](./logo-angular.jpg)](https://angular.io/) [![Electron Logo](./logo-electron.jpg)](https://electron.atom.io/)
-
+<a href='https://angular.io/'><img src='./logo-angular.jpg' width='75' alt='Angular Logo'></a>
+<a href='https://electron.atom.io/'><img src='./logo-electron.jpg' alt='Electron Logo'></a>
 
 [![Travis Build Status][build-badge]][build]
 [![Dependencies Status][dependencyci-badge]][dependencyci]
@@ -20,10 +20,10 @@ Bootstrap and package your project with Angular 5(+) and Electron (Typescript + 
 
 Currently runs with:
 
-- Angular v5.0.1
-- Angular-CLI v1.5.0
-- Electron v1.7.6
-- Electron Packager v9.0.1
+- Angular v5.2.0
+- Angular-CLI v1.6.4
+- Electron v1.7.8
+- Electron Builder v19.45.4
 
 With this sample, you can :
 


### PR DESCRIPTION
The _Angular_ logo is much larger than the _Electron_ logo and it doesn't look as good as when they are even in size.

The _README.md_ had outdated versions of packages listed.

This PR fixes both.