### PR TITLE
Fix to change environment

### DIFF
--- a/hooks/environments/set_profile.js
+++ b/hooks/environments/set_profile.js
@@ -7,7 +7,7 @@ var path = require('path');
 var profile = process.env.ENV ? process.env.ENV : 'local';
 
 console.log('Déplacement du template de fichier de détection de configuration ...');
-fs.copySync(path.resolve(__dirname,'./app.config.ts.tpl'), path.resolve(__dirname,'../src/app/app.config.ts'));
+fs.copySync(path.resolve(__dirname,'./app.config.ts.tpl'), path.resolve(__dirname,'../../src/app/app.config.ts'));
 
 console.log('Application du profil : ' + profile);
 


### PR DESCRIPTION
It was always building production environment despite using `cross-env ENV=dev` preapended to `npm start` (at least at windows).