### PR TITLE
Terminate the npm process after test execution

### DIFF
--- a/e2e/app.e2e-spec.ts
+++ b/e2e/app.e2e-spec.ts
@@ -9,6 +9,7 @@ describe('angular-electron App', () => {
   });
 
   it('should display message saying App works !', () => {
+    page.navigateTo('/');
     expect(element(by.css('app-home h1')).getText()).toMatch('App works !');
   });
 });

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "electron:windows": "npm run build:prod && npx electron-builder build --windows",
     "electron:mac": "npm run build:prod && npx electron-builder build --mac",
     "test": "karma start ./karma.conf.js",
-    "pree2e:build": "webdriver-manager update --gecko false && npm run ng:serve",
+    "pree2e:build": "webdriver-manager update --gecko false && npm run ng serve",
     "pree2e:protractor": "wait-on http-get://localhost:4200/ && protractor ./protractor.conf.js",
-    "e2e": "npm-run-all -p pree2e:build pree2e:protractor"
+    "e2e": "npm-run-all -p -r pree2e:build pree2e:protractor"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
This will fix `npm run e2e`(based on PR #161) and terminate the npm process after the test execution is done