### PR TITLE
feat(zone): add zone-patch-electron to patch Electron native APIs in polyfills.

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -72,7 +72,12 @@ import 'core-js/es7/reflect';
  */
 import 'zone.js/dist/zone-mix';  // Included with Angular CLI.
 
-
+/**
+ * You can load zone-patch-electron to allow electron native APIs
+ * (Such as dialog/shortcut/menu/getFileIcon/shell/session/
+ * desktopCapturer/onEvent) in ngZone
+ */
+// import 'zone.js/dist/zone-patch-electron'; // add zone-patch-electron to patch Electron native API
 
 /***************************************************************************************************
  * APPLICATION IMPORTS


### PR DESCRIPTION
`zone.js` provide Electron native APIs support to make those APIs' callback run in zone.
Includes:

- on event
- dialog
- shortcut
- menu item
- app method, such as getFileIcon
- shell
- session
- desktopCapturer

So in this PR, add a commented line in `polyfills.ts`.

```
// import 'zone.js/dist/zone-patch-electron'; // add zone-patch-electron to patch Electron native API
```