### PR TITLE
Allow Angular Using Electron Modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "main": "main.js",
   "private": true,
   "scripts": {
-    "postinstall": "npx electron-builder install-app-deps",
+    "postinstall": "npx electron-builder install-app-deps && node postinstall",
     "ng": "ng",
     "start": "npm-run-all -p ng:serve electron:serve",
     "build": "npm run electron:tsc && ng build",

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,15 @@
+// Allow angular using electron module (native node modules)
+const fs = require('fs');
+const f_angular = 'node_modules/@angular-devkit/build-angular/src/angular-cli-files/models/webpack-configs/browser.js';
+
+fs.readFile(f_angular, 'utf8', function (err, data) {
+  if (err) {
+    return console.log(err);
+  }
+  var result = data.replace(/target: "electron-renderer",/g, '');
+  var result = result.replace(/return \{/g, 'return {target: "electron-renderer",');
+
+  fs.writeFile(f_angular, result, 'utf8', function (err) {
+    if (err) return console.log(err);
+  });
+});


### PR DESCRIPTION
This PR allows Angular using electron modules and native node modules, such as child_process, crypto and so on.