### PR TITLE
Update electron-builder.json files rule

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -5,7 +5,7 @@
   },
     "files": [
         "**/*",
-        "!*.ts",
+        "!**/*.ts",
         "!*.code-workspace",
         "!LICENSE.md",
         "!package.json",
@@ -13,7 +13,7 @@
         "!src/",
         "!e2e/",
         "!hooks/",
-        "!.angular-cli.json",
+        "!angular.json",
         "!_config.yml",
         "!karma.conf.js",
         "!tsconfig.json",


### PR DESCRIPTION
- ".angular-cli.json" has been renamed in Angular 6 for "angular.json"
- Found out that some nested typscript files were still bundled