### PR TITLE
Not gitignore src/karma.conf.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /release
 main.js
 src/**/*.js
+!src/karma.conf.js
 *.js.map
 
 # dependencies


### PR DESCRIPTION
src/karma.conf.js exists in this repository but gitignored.
This causes those who copied & pasted the files to get started using this repo to encounter things like these:
 - Changes on karma.conf.js being not tracked by Git.
 - CI failure (because their repo cloned on CI server does not contain karma.conf.js)