### PR TITLE
Fix Travis CI Link for CI Status Badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Note that you can't use Electron or NodeJS native libraries in this case. Please
 - Angular 7 & Electron 3 : (master)
 
 [build-badge]: https://travis-ci.org/maximegris/angular-electron.svg?branch=master
-[build]: https://travis-ci.org/maximegris/angular-electron.svg?branch=master
+[build]: https://travis-ci.org/maximegris/angular-electron
 [dependencyci-badge]: https://dependencyci.com/github/maximegris/angular-electron/badge
 [dependencyci]: https://dependencyci.com/github/maximegris/angular-electron
 [license-badge]: https://img.shields.io/badge/license-Apache2-blue.svg?style=flat


### PR DESCRIPTION
Currently, clicking the badge navigates to the badge image.
With this fix, it will navigate to the CI status page, which is the default and more useful behavior of the badge.