### PR TITLE
Run CI on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - npm set progress=false
   - npm install
 script:
-  - ng lint
+  - npm run lint
   - npm run test
   - npm run e2e
   - npm run build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+environment:
+  matrix:
+    - nodejs_version: "10"
+
+platform:
+  - x64
+
+# Install scripts. (runs after repo cloning)
+install:
+  - choco upgrade googlechrome
+  - dir C:\avvm\node            # Print available versions of Node.js in AppVeyor
+  - ps: Install-Product node $env:nodejs_version $env:platform
+  - npm set progress=false
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm run lint
+  - npm run test
+  - npm run e2e
+  - npm run build
+
+# Don't actually build.
+build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-    - nodejs_version: "8"
     - nodejs_version: "10"
 
 platform:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   matrix:
+    - nodejs_version: "8"
     - nodejs_version: "10"
 
 platform:

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "electron:linux": "npm run build:prod && electron-builder build --linux",
     "electron:windows": "npm run build:prod && electron-builder build --windows",
     "electron:mac": "npm run build:prod && electron-builder build --mac",
+    "lint": "ng lint",
     "test": "npm run postinstall:web && ng test",
     "e2e": "npm run postinstall:web && ng e2e",
     "version": "conventional-changelog -i CHANGELOG.md -s -r 0 && git add CHANGELOG.md"


### PR DESCRIPTION
This PR adds the necessary changes to run CI for Windows in AppVeyor.
For my forked repo, it works like this:
https://ci.appveyor.com/project/TomoyukiAota/angular-electron/builds/21909496

To run AppVeyor, the repository owner needs to do the following things:
 - Create an AppVeyor account (if you don't have).
 - Specify this repo in AppVeyor's configuration. The configuration should be easy (that is, a few clicks).

One thing I noticed is that `npm run e2e` throws an error for Node.js version 8. In AppVeyor, the message is displayed here:
https://ci.appveyor.com/project/TomoyukiAota/angular-electron/builds/21908627/job/owugnm8q251wwql6
A similar error occurred on my local PC with version 8.15.0. (On AppVeyor, it is 8.12.0.)
Therefore, I specified version 10 instead of version 8 in `appveyor.yml`.