### PR TITLE
Electron 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "codelyzer": "4.5.0",
     "conventional-changelog-cli": "2.0.11",
     "core-js": "2.6.1",
-    "electron": "4.0.0",
+    "electron": "5.0.1",
     "electron-builder": "20.36.2",
     "electron-reload": "1.3.0",
     "jasmine-core": "3.3.0",


### PR DESCRIPTION
Surprisingly easy update! No problems after updating the package and starting the app 👌 

Note, Electron 5 uses `Node 12` internally, though it doesn't seem to cause any trouble.

Electron 5 released 13 days ago: https://github.com/electron/electron/releases/tag/v5.0.0