### PR TITLE
Specify base filename for electron builder icons

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -20,19 +20,19 @@
         "!tslint.json"
     ],
   "win": {
-    "icon": "dist",
+    "icon": "dist/favicon",
     "target": [
       "portable"
     ]
   },
   "mac": {
-    "icon": "dist",
+    "icon": "dist/favicon",
     "target": [
       "dmg"
     ]
   },
   "linux": {
-    "icon": "dist",
+    "icon": "dist/favicon",
     "target": [
       "AppImage"
     ]


### PR DESCRIPTION
Adding /favicon to the icon path inside the electron builder config resolves the issue where it tries to use a file that is not ment to be an app icon.   

E.g. a small Facebook icon inside the assets folder results in this error while building the app:
`  ⨯ image ...\dist\facebook.06343e03805a95d6b367.png must be at least 256x256            error Command failed with exit code 1.      `