### PR TITLE
Transparent background issue fix for Linux

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -58,7 +58,8 @@ try {
   // This method will be called when Electron has finished
   // initialization and is ready to create browser windows.
   // Some APIs can only be used after this event occurs.
-  app.on('ready', createWindow);
+  // Added 400 ms to fix the black background issue while using transparent window. More detais at https://github.com/electron/electron/issues/15947
+  app.on('ready', () => setTimeout(createWindow, 400));
 
   // Quit when all windows are closed.
   app.on('window-all-closed', () => {


### PR DESCRIPTION
When window transparency is enabled for the Linux target application, a black window is displaying instead of a transparent one.

According to the issues in the official repo of electron (https://github.com/electron/electron/issues/15947), the background transparency is working as expected when a 400 ms delay is applied.

The code is updated and checked. It worked as expected. Kindly review and merge. 

Thanks,
Srinivas Batchu