### PR TITLE
fix/ Karma configuration to debug easily

### DIFF
--- a/src/karma.conf.js
+++ b/src/karma.conf.js
@@ -30,16 +30,17 @@ module.exports = function (config) {
     customLaunchers: {
       AngularElectron: {
         base: 'Electron',
+        flags: [
+          '--remote-debugging-port=9222'
+        ],
         browserWindowOptions: {
           webPreferences: {
             nodeIntegration: true,
+            nodeIntegrationInSubFrames: true,
             allowRunningInsecureContent: true
           }
         }
       }
-    },
-    client: {
-      useIframe: false
     }
   });
 };


### PR DESCRIPTION
I wasn't able to make intellij remote debugger working until I found this configuration.
- We keep karma executing in iframe but enable node integration in subframes
- Specifying the remote debugging port by default which allows intellij to listen this port automatically

I don't know if this is the best way to do this but I think it should not break the features in others IDE.
What do you think about it ?