### PR TITLE
Fix default styleextension

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -162,7 +162,8 @@
   "schematics": {
     "@schematics/angular:component": {
       "prefix": "app",
-      "styleext": "scss"
+      "styleext": "scss",
+      "style": "scss"
     },
     "@schematics/angular:directive": {
       "prefix": "app"


### PR DESCRIPTION
Angular CLI 9 reads the "style" key instead of "styleext" from inside the schematics.