### PR TITLE
Proposed fix to get 'npm run start' work again with crypto

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,12 @@
   "scripts": {
     "postinstall": "electron-builder install-app-deps",
     "ng": "ng",
-    "start": "npm-run-all -p electron:serve ng:serve",
+    "start": "npm-run-all -p electron:serve ng:serve:plain",
     "build": "npm run electron:serve-tsc && ng build --base-href ./",
     "build:dev": "npm run build -- -c dev",
     "build:prod": "npm run build -- -c production",
     "ng:serve": "ng serve -c web -o",
+    "ng:serve:plain": "ng serve",
     "electron:serve-tsc": "tsc -p tsconfig.serve.json",
     "electron:serve": "wait-on tcp:4200 && npm run electron:serve-tsc && npx electron . --serve",
     "electron:local": "npm run build:prod && npx electron .",


### PR DESCRIPTION
Not sure it is the best naming for `ng:serve:plain`, but as `ng:serve` now includes the `web` part, which makes things like `crypto` fail, I propose to revert to something like this.

Closes #518