### PR TITLE
Fix typo in eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -58,7 +58,7 @@
       "parser": "@angular-eslint/template-parser",
       "plugins": ["@angular-eslint/template"],
       "rules": {
-          "@angular-eslint/template/banana-in-a-box": "error",
+          "@angular-eslint/template/banana-in-box": "error",
           "@angular-eslint/template/no-negated-async": "error"
       }
     }


### PR DESCRIPTION
Hello, thanks for this awesome repository, it saved a lot of time for me!

Found a little typo in eslint rule.

Before (incorrect):

![image](https://user-images.githubusercontent.com/53087914/98388025-fe9d9480-2073-11eb-80b0-7bf36600f952.png)

After (correct):

![image](https://user-images.githubusercontent.com/53087914/98388141-2c82d900-2074-11eb-8582-8876b2b58035.png)