### PR TITLE
update electron version to include bug fix for setWindowOpenHandler 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Bootstrap and package your project with Angular 11 and Electron 12 (Typescript +
 Currently runs with:
 
 - Angular v11.2.8
-- Electron v12.0.2
+- Electron v12.0.6
 - Electron Builder v22.10.5
 
 With this sample, you can:

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "conventional-changelog-cli": "2.1.1",
     "core-js": "3.6.5",
     "cross-env": "7.0.3",
-    "electron": "12.0.2",
+    "electron": "12.0.6",
     "electron-builder": "22.10.5",
     "electron-reload": "1.5.0",
     "eslint": "7.22.0",


### PR DESCRIPTION
# Description

webContents.on("new-window") is deprecated  and current version 12.0.2 does not trigger setWindowOpenHandler for ctrl+click on links. It is resolved by 12.0.5.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests (npm run test & npm run e2e) that prove my fix is effective or that my feature works
