### PR TITLE
remove include statement from base tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,9 +20,6 @@
       "dom"
     ]
   },
-  "include": [
-    "src/**/*.d.ts"
-  ],
   "exclude": [
     "node_modules"
   ]


### PR DESCRIPTION
# Description

Base tsconfig.json file has "includes" statement for files that match the "src/**/*.d.ts" glob.
This doesn't include all *.ts files, which causes issues with IDE's (Specifically VS Code)
![image](https://user-images.githubusercontent.com/7328874/134452458-b0aee9ef-ae7c-4bc8-a2ef-c4fc440be252.png)

What I've done is remove the "includes" statement so that it's similar to the structure of a base angular 12 app (app when creating application with `ng new`)

Please let me know if any changes need to be made to this pull request as there are multiple ways to fix this issue and I am uncertain which one would be considered the best option.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests (npm run test & npm run e2e) that prove my fix is effective or that my feature works

Additional steps taken to test:

- ran `ng build`.
- ran `ng build -c production`
