### PR TITLE
Add missing @ on the SCSS import for Material theme fix

### DIFF
--- a/HOW_TO.md
+++ b/HOW_TO.md
@@ -34,6 +34,6 @@ Your project is not using the default builders for "build". The Angular Material
 *No need to Panic!* Just add your desired theme in style.scss:
 
 ``` bash
-import '@angular/material/prebuilt-themes/indigo-pink.css'
+@import '@angular/material/prebuilt-themes/indigo-pink.css'
 ```
 Angular Material Library is now installed in your project.


### PR DESCRIPTION
# Description

The How-To guide had a missing @ on the line with the fix for the Angular Material theme.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests (npm run test & npm run e2e) that prove my fix is effective or that my feature works
