### PR TITLE
fix renderer process debugger regression after Angular 19 branch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,9 +13,6 @@
             "sourceMaps": true,  
             "timeout": 10000,
             "trace": "verbose",
-            "sourceMapPathOverrides": {
-                "webpack:///./*": "${workspaceFolder}/*"
-            },
             "preLaunchTask": "Build.Renderer"
         },
         {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -41,7 +41,7 @@
           "background": {
             "activeOnStart": true,
             "beginsPattern": "^.*",
-            "endsPattern": "^.*Compiled successfully.*"
+            "endsPattern": "Application bundle generation complete"
           }
         }
       }

--- a/angular.json
+++ b/angular.json
@@ -72,7 +72,7 @@
                   "with": "src/environments/environment.prod.ts"
                 }
               ]
-            }
+            },
             "testing": {
               "polyfills": [
                 "zone.js",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "postinstall": "electron-builder install-app-deps",
     "ng": "ng",
     "start": "npm-run-all -p electron:serve ng:serve",
-    "ng:serve": "ng serve -o",
+    "ng:serve": "ng serve -c dev -o",
     "build": "npm run electron:serve-tsc && ng build --base-href ./",
     "web:dev": "npm run build",
     "web:prod": "npm run build -- -c production",


### PR DESCRIPTION
# Description

Fixes a configuration regression introduced after the Angular 19 branch that prevented VS Code from properly debugging the renderer process.  
This change updates `.vscode/launch.json`, `.vscode/tasks.json`, `angular.json`, and `package.json` to restore correct debugger behavior and ensure breakpoints are hit.

Fixes #848

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have run tests (npm run test & npm run e2e) that prove my fix is effective or that my feature works

# Details

1. `.vscode/launch.json`: removed `"sourceMapPathOverrides"` because Webpack is no longer used.  
2. `.vscode/tasks.json`: updated prelaunch and background tasks to match Angular 21 build output. `"endsPattern"` changed from `"^.*Compiled successfully.*"` to `"Application bundle generation complete"` to correctly detect when the Angular dev server has finished building.

![Angular 19 build output](https://github.com/user-attachments/assets/3de7dc5a-a842-467e-bdb5-076483b229e8)
![Angular 21 build output](https://github.com/user-attachments/assets/7a81ffbe-eede-4f75-bae4-f4f23c9ae1b9)

3. `angular.json`: added missing comma in environment configuration
4. `package.json`: update "ng:serve" script to include dev configuration (`-c dev`)