### PR TITLE
feat: add IPC handlers for app.getPath and app.getVersion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ Thumbs.db
 
 .claude
 CLAUDE.local.md
+
+.worktrees

--- a/app/main.ts
+++ b/app/main.ts
@@ -60,7 +60,6 @@ function createWindow(): BrowserWindow {
 }
 
 try {
-  ipcMain.handle('app:get-path', (_, name: Parameters<typeof app.getPath>[0]) => app.getPath(name));
   ipcMain.handle('app:get-version', () => app.getVersion());
 
   // This method will be called when Electron has finished

--- a/app/main.ts
+++ b/app/main.ts
@@ -1,4 +1,4 @@
-import {app, BrowserWindow, screen} from 'electron';
+import {app, BrowserWindow, ipcMain, screen} from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
 
@@ -60,6 +60,9 @@ function createWindow(): BrowserWindow {
 }
 
 try {
+  ipcMain.handle('app:get-path', (_, name: Parameters<typeof app.getPath>[0]) => app.getPath(name));
+  ipcMain.handle('app:get-version', () => app.getVersion());
+
   // This method will be called when Electron has finished
   // initialization and is ready to create browser windows.
   // Some APIs can only be used after this event occurs.

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -26,6 +26,7 @@ export class AppComponent {
       console.log('Run in electron');
       console.log('Electron ipcRenderer', this.electronService.ipcRenderer);
       console.log('NodeJS childProcess', this.electronService.childProcess);
+      void this.electronService.ipcRenderer.invoke('app:get-version').then(v => console.log('App version:', v));
     } else {
       console.log('Run in browser');
     }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -11,8 +11,6 @@ import { TranslateModule } from '@ngx-translate/core';
 })
 export class HomeComponent implements OnInit {
 
-  constructor() { }
-
   ngOnInit(): void {
     console.log('HomeComponent INIT');
   }


### PR DESCRIPTION
## Summary

- `app` is main-process only — accessing it via `window.require('electron').app` in the renderer returns `undefined`
- Adds `ipcMain.handle('app:get-version', ...)` in `app/main.ts`
- Demonstrates usage in `AppComponent` via `ipcRenderer.invoke('app:get-version')`

## Test plan

- [ ] Run `npm start` and check DevTools console — "App version: x.x.x" should appear
- [ ] Lint passes: `npm run lint`
- [ ] Unit tests pass: `npm test`

Closes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)