### PR TITLE
fix: prevent dev-mode reload loop on macOS

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -31,7 +31,9 @@ function createWindow(): BrowserWindow {
 
     import('electron-reloader').then(reloader => {
       const reloaderFn = (reloader as any).default || reloader;
-      reloaderFn(module);
+      // watchRenderer: false — Angular dev server handles HMR for the renderer.
+      // Without this, reloader triggers spurious reloads on macOS (issue #840).
+      reloaderFn(module, { watchRenderer: false });
     });
     win.loadURL('http://localhost:4200');
   } else {


### PR DESCRIPTION
Fixes #840

## Problem
`electron-reloader` defaults to `watchRenderer: true`, which watches renderer-process files in addition to the main process. On macOS, Angular's dev server writing files at startup triggers a reload loop.

## Fix
Pass `{ watchRenderer: false }` when calling the reloader. Angular's dev server already handles HMR for the renderer, so there is no loss of functionality.

## Testing
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [ ] Manual test on macOS: `npm start`, confirm no reload loop after initial startup