### PR TITLE
fix: add TSC watch for main process hot-reload in dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-electron",
   "version": "17.0.0",
-  "description": "Angular 21 with Electron 39 (Typescript + SASS + Hot Reload)",
+  "description": "Angular 21 with Electron 40 (Typescript + SASS + Hot Reload)",
   "homepage": "https://github.com/belnadris/angular-electron",
   "author": {
     "name": "Maxime GRIS",
@@ -34,7 +34,9 @@
     "web:prod": "npm run build -- -c production",
     "electron": "electron",
     "electron:serve-tsc": "tsc -p tsconfig.serve.json",
-    "electron:serve": "wait-on tcp:4200 && npm run electron:serve-tsc && electron . --serve",
+    "electron:serve-tsc:watch": "tsc -p tsconfig.serve.json --watch --preserveWatchOutput",
+    "electron:start": "electron . --serve",
+    "electron:serve": "wait-on tcp:4200 && npm run electron:serve-tsc && npm-run-all -p electron:serve-tsc:watch electron:start",
     "electron:local": "npm run web:dev && electron .",
     "electron:build": "npm run web:prod && electron-builder build --publish=never",
     "test": "ng test --watch=false",


### PR DESCRIPTION
## Summary

- Add `electron:serve-tsc:watch` script: runs `tsc -p tsconfig.serve.json --watch --preserveWatchOutput`
- Add `electron:start` script: `electron . --serve`
- Update `electron:serve` to: initial compile → then run TSC watch + Electron in parallel

## Problem

Since PR #859 applied `{ watchRenderer: false }` to `electron-reloader`, the reloader only watches `app/main.js` for changes. But `electron:serve-tsc` was a one-time compile with no `--watch`, so `app/main.js` never changed during dev. Changes to `app/main.ts` had no effect until manually restarting `npm start`.

## How it works

1. `wait-on tcp:4200` — waits for Angular dev server
2. `npm run electron:serve-tsc` — one-time compile so `app/main.js` exists before Electron starts
3. `npm-run-all -p electron:serve-tsc:watch electron:start` — runs TSC watch + Electron in parallel
   - TSC watch recompiles `app/main.js` on every `app/main.ts` save
   - `electron-reloader` detects the updated `app/main.js` → relaunches Electron

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm run build` passes
- [ ] `npm start`, edit `app/main.ts`, save → Electron restarts with changes applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)