### PR TITLE
i18n: add Korean (ko) translation

### DIFF
--- a/src/assets/i18n/ko.json
+++ b/src/assets/i18n/ko.json
@@ -1,0 +1,12 @@
+{
+  "PAGES": {
+      "HOME": {
+          "TITLE": "앱이 작동합니다!",
+          "GO_TO_DETAIL": "상세 페이지로 이동"
+      },
+      "DETAIL": {
+        "TITLE": "상세 페이지!",
+        "BACK_TO_HOME": "홈으로 돌아가기"
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

This adds Korean (`ko`) translation support — to help Korean-speaking users use this
open-source project more comfortably in their own language.
(한국 사람들의 오픈소스 이용에 도움이 되게 하기 위해서 한글화 작업을 하였습니다.)

## Changes

- Added `src/assets/i18n/ko.json` with a full Korean translation of every key present in `src/assets/i18n/en.json` (4/4 keys, same nested structure: `PAGES.HOME.TITLE`, `PAGES.HOME.GO_TO_DETAIL`, `PAGES.DETAIL.TITLE`, `PAGES.DETAIL.BACK_TO_HOME`).
- No changes to app code, routing, or the existing `provideTranslateService` config — this app currently hardcodes `lang: 'en'` and has no language switcher, so this PR only adds the translation resource file for the existing `ngx-translate` + `TranslateHttpLoader` setup (`prefix: './assets/i18n/', suffix: '.json'`) to pick up if/when a `ko` locale is requested.

## Testing

- Verified key parity between `en.json` and `ko.json` with a script (4/4 keys match, none missing/extra).
- Ran `npm run lint` — all files pass linting.
- Ran `npm run web:dev` (production build) — build succeeds and `dist/browser/assets/i18n/ko.json` is emitted correctly alongside `en.json`.